### PR TITLE
fix: Add create_parents to argument_spec

### DIFF
--- a/json_patch.py
+++ b/json_patch.py
@@ -576,6 +576,7 @@ def main():
             unsafe_writes=dict(required=False, default=False, type='bool'),
             pretty=dict(required=False, default=False, type='bool'),
             create=dict(required=False, default=False, type='bool'),
+            create_parents=dict(required=False, default=False, type='bool'),
             create_type=dict(required=False, default='object', type='str'),
         ),
         supports_check_mode=True


### PR DESCRIPTION
When trying to use `create_parents` I get "no such argument in module" .

This adds `create_parents` to the list of supported arguments.